### PR TITLE
[GITHUB-3] Adds missing platform tags

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,6 +5,11 @@ galaxy_info:
   license: MIT
   min_ansible_version: 2.2
   min_ansible_container_version: 2.2
+  platforms:
+    - name: Ubuntu
+      versions:
+        - trusty
+        - xenial
   galaxy_tags:
     - aws
     - cloud


### PR DESCRIPTION
Just set to Trusty and Xenial for now, technically this works
anywhere but I can't find a 'works anywhere' option.