### PR TITLE
[GITHUB-7] Ansible 2.9 upgrade - remove Trusty

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,7 +9,6 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
   galaxy_tags:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,8 +9,6 @@ driver:
 # See https://molecule.readthedocs.io/en/latest/configuration.html#platforms for details.
 # NOTE: Different drivers (see above) may have different configuration options.
 platforms:
-  - name: aws-dynamo-db-trusty
-    image: ubuntu:trusty
   - name: aws-dynamo-db-xenial
     image: ubuntu:xenial
   - name: aws-dynamo-db-bionic


### PR DESCRIPTION
updated to remove support for Ubuntu Trusty